### PR TITLE
Allow users to opt out of the `CA Certificates` buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The buildpack optionally accepts the following bindings:
 |----------------------|---------|------------
 |`<certificate-name>` | `<certificate>` | CA certificate to trust. Should contain exactly one PEM encoded certificate.
 
+## Configuration
+| Environment Variable | Description
+| -------------------- | -----------
+| `$BP_ENABLE_RUNTIME_CERT_BINDING` | Enable/disable the ability to set certificates at runtime via the certificate helper layer. Default is true.
+
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -26,6 +26,11 @@ id = "io.buildpacks.stacks.bionic"
 [[stacks]]
 id = "io.paketo.stacks.tiny"
 
+[[metatdata.configurations]]
+name        = "BP_ENABLE_RUNTIME_CERT_BINDING"
+description = "Enable/disable certificate helper layer to add certs at runtime"
+build       = true
+
 [metadata]
 pre-package   = "scripts/build.sh"
 include-files = [

--- a/cacerts/build.go
+++ b/cacerts/build.go
@@ -42,6 +42,11 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	b.Logger.Title(context.Buildpack)
 
+	_, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
+	}
+
 	var certPaths []string
 	var contributedHelper bool
 	for _, e := range context.Plan.Entries {

--- a/cacerts/detect.go
+++ b/cacerts/detect.go
@@ -76,12 +76,10 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 	if err != nil {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}
-	if ok, err := d.runtimeCertBindingEnabled(cr); err != nil {
-		return libcnb.DetectResult{}, err
-	} else if !ok {
-		// If there are no bindings either, we should fail detection outright
-		if len(paths) == 0 {
-			result.Pass = false
+
+	if ok, err := d.runtimeCertBindingEnabled(cr); !ok {
+		if err != nil {
+			return libcnb.DetectResult{}, err
 		}
 		return result, nil
 	}

--- a/cacerts/detect_test.go
+++ b/cacerts/detect_test.go
@@ -95,7 +95,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		context("BP_ENABLE_RUNTIME_CERT_BINDING is set to false", func() {
 			var result libcnb.DetectResult
 			it.Before(func() {
-				// ctx.Platform.Environment = map[string]string{"BP_ENABLE_RUNTIME_CERT_BINDING": "false"}
 				os.Setenv("BP_ENABLE_RUNTIME_CERT_BINDING", "false")
 
 				var err error
@@ -175,7 +174,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		context("BP_ENABLE_RUNTIME_CERT_BINDING is set to false", func() {
 			var result libcnb.DetectResult
 			it.Before(func() {
-				// ctx.Platform.Environment = map[string]string{"BP_ENABLE_RUNTIME_CERT_BINDING": "false"}
 				os.Setenv("BP_ENABLE_RUNTIME_CERT_BINDING", "false")
 
 				var err error
@@ -187,8 +185,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				os.Unsetenv("BP_ENABLE_RUNTIME_CERT_BINDING")
 			})
 
-			it("detect fails", func() {
-				Expect(result.Pass).To(BeFalse())
+			it("detect passes", func() {
+				Expect(result.Pass).To(BeTrue())
 			})
 
 			it("first plan does not require ca-certificates", func() {

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,10 @@ go 1.15
 
 require (
 	github.com/buildpacks/libcnb v1.19.0
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/onsi/gomega v1.11.0
 	github.com/paketo-buildpacks/libpak v1.51.0
 	github.com/sclevine/spec v1.4.0
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
+	golang.org/x/sys v0.0.0-20210324051608-47abb6519492 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/buildpacks/libcnb v1.19.0 h1:7Frn3qErlVmQydk95YXmHtpmf5bZ1l7h4rK/C+SKAmY=
 github.com/buildpacks/libcnb v1.19.0/go.mod h1:slnOsywO4mNdkShkwX1GYR+kQF1tH2F9Urfr66lWGQs=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -30,6 +31,8 @@ github.com/heroku/color v0.0.6/go.mod h1:ZBvOcx7cTF2QKOv4LbmoBtNl5uB17qWxGuzZrsi
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
@@ -56,6 +59,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -81,6 +85,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Will resolve #32.

## Use Cases
<!-- An explanation of the use cases your change enables -->

A user can build their image with the `$BP_ENABLE_RUNTIME_CERT_BINDING` set to false in order to disable the certificate helper layer.

Detection will fail if both conditions are met:
1. No CA Cert bindings are provided
2. This env. var is set

Detection will pass, but no helper layer will be available (cannot add certificates at runtime) in the following scenario:
1. A CA Cert binding is provided
2. This env. var is set

Detection will pass as normal with the helper layer whenever the environment variable is not set.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
