### PR TITLE
Bug fix for read-only containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ The buildpack configures trusted certs at both build and runtime by:
 
 To learn about the conventional meaning of `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables see the OpenSSL documentation for [SSL_CTX_load_verify_locations][s]. This buildpack may not work with tools that do not respect these environment variables.
 
+### Runtime Environment Support
+
+| Feature              | Supported       | Detail                                                                  |
+| -------------------- | --------------- | ---------------------------------------------------------------------------- |
+| read-only runtime container | No       | Symlinks and/or new files are written for certificates provided via binding at runtime. A read-only container will run if no cert bindings are present at runtime.  |
+| run as custom user          | Yes      | The custom user must be a member of the `CNB` group
+
+
+
 ## Bindings
 
 The buildpack optionally accepts the following bindings:

--- a/cacerts/execd.go
+++ b/cacerts/execd.go
@@ -53,14 +53,14 @@ func NewExecD(bindings libcnb.Bindings) *ExecD {
 func (e *ExecD) Execute() (map[string]string, error) {
 	env := map[string]string{}
 	var splitPaths []string
+
+	paths := getsCertsFromBindings(e.Bindings)
+	if len(paths) == 0 {
+		return env, nil
+	}
 	certDir, err := ioutil.TempDir("", "ca-certificates")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir\n%w", err)
-	}
-
-	paths := getsCertsFromBindings(e.Bindings)
-	if len(paths) == 0 || err != nil {
-		return env, err
 	}
 	for _, p := range paths {
 		if extraPaths, err := SplitCerts(p, certDir); err != nil {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes #106 

## Use Cases
A temp directory is created when additional certificates are supplied (e.g. via binding) for addition to the JVM truststore. Read-only containers with no extra certificates added via bindings should start successfully.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
