### PR TITLE
Several minor fixes

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the original author or authors.
+# Copyright 2018-2024 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,42 +27,32 @@ api = "0.7"
     type = "Apache-2.0"
     uri = "https://github.com/paketo-buildpacks/ca-certificates/blob/main/LICENSE"
 
-[[targets]]
-os = "linux"
-arch = "amd64"
-
-[[targets]]
-os = "linux"
-arch = "arm64"
-
 [metadata]
   include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/amd64/bin/helper", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "linux/arm64/bin/helper", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
-[metatdata]
-
-  [[metatdata.configurations]]
+  [[metadata.configurations]]
     build = true
-    default = false
+    default = "false"
     description = "Disable certificate helper layer to add certs at runtime"
     name = "BP_RUNTIME_CERT_BINDING_DISABLED"
 
-  [[metatdata.configurations]]
+  [[metadata.configurations]]
     build = true
-    default = false
+    default = "false"
     description = "Embed certificates into the image"
     name = "BP_EMBED_CERTS"
 
-  [[metatdata.configurations]]
+  [[metadata.configurations]]
     build = true
+    default = "true"
     description = "Deprecated: Enable/disable certificate helper layer to add certs at runtime"
     name = "BP_ENABLE_RUNTIME_CERT_BINDING"
 
-[[stacks]]
-  id = "io.buildpacks.stacks.bionic"
+[[targets]]
+  os = "linux"
+  arch = "amd64"
 
-[[stacks]]
-  id = "io.paketo.stacks.tiny"
-
-[[stacks]]
-  id = "*"
+[[targets]]
+  os = "linux"
+  arch = "arm64"

--- a/cacerts/build.go
+++ b/cacerts/build.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package cacerts
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -48,7 +48,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}
 
-	certDir, err := ioutil.TempDir("", "ca-certificates")
+	certDir, err := os.MkdirTemp("", "ca-certificates")
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create temporary directory for certificates\n%w", err)
+	}
 
 	var certPaths []string
 	var contributedHelper bool

--- a/cacerts/build_test.go
+++ b/cacerts/build_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package cacerts_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,9 +38,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-		ctx.Layers.Path, err = ioutil.TempDir("", "build-layers")
-		Expect(err).NotTo(HaveOccurred())
+		ctx.Layers.Path = t.TempDir()
 
 		build = cacerts.Build{}
 	})

--- a/cacerts/certs.go
+++ b/cacerts/certs.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -55,7 +54,7 @@ func GenerateHashLinks(dir string, certPaths []string) error {
 	hashes := map[uint32][]string{}
 	sort.Strings(certPaths)
 	for _, path := range certPaths {
-		raw, err := ioutil.ReadFile(path)
+		raw, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to read file at path %q\n%w", path, err)
 		}
@@ -175,7 +174,7 @@ func SplitCerts(path string, certDir string) ([]string, error) {
 	var block *pem.Block
 	var rest []byte
 
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file at path %q\n%w", path, err)
 	}
@@ -190,7 +189,7 @@ func SplitCerts(path string, certDir string) ([]string, error) {
 	}
 	for ind := 0; block != nil; ind++ {
 		newCertPath := filepath.Join(certDir, fmt.Sprintf("cert_%d_%s", ind, filepath.Base(path)))
-		if os.WriteFile(newCertPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: block.Bytes}), 0777); err != nil {
+		if err = os.WriteFile(newCertPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: block.Bytes}), 0777); err != nil {
 			return nil, fmt.Errorf("failed to write extra certficate to file\n%w", err)
 		}
 		paths = append(paths, newCertPath)

--- a/cacerts/certs_test.go
+++ b/cacerts/certs_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,9 +40,7 @@ func testCerts(t *testing.T, context spec.G, it spec.S) {
 		var dir string
 
 		it.Before(func() {
-			var err error
-			dir, err = ioutil.TempDir("", "hash-links-test")
-			Expect(err).NotTo(HaveOccurred())
+			dir = t.TempDir()
 		})
 
 		it.After(func() {
@@ -57,23 +54,29 @@ func testCerts(t *testing.T, context spec.G, it spec.S) {
 				filepath.Join("testdata", "SecureTrust_CA_Duplicate.pem"),
 			})
 			Expect(err).NotTo(HaveOccurred())
-			fis, err := ioutil.ReadDir(dir)
+			fis, err := os.ReadDir(dir)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(fis)).To(Equal(3))
 
-			Expect(fis[0].Mode() & os.ModeType).To(Equal(os.ModeSymlink))
+			info, err := fis[0].Info()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.Mode() & os.ModeType).To(Equal(os.ModeSymlink))
 			target, err := os.Readlink(filepath.Join(dir, fis[0].Name()))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(target).To(Equal("testdata/Go_Daddy_Class_2_CA.pem"))
 			Expect(fis[0].Name()).To(Equal("f081611a.0"))
 
-			Expect(fis[1].Mode() & os.ModeType).To(Equal(os.ModeSymlink))
+			info, err = fis[1].Info()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.Mode() & os.ModeType).To(Equal(os.ModeSymlink))
 			target, err = os.Readlink(filepath.Join(dir, fis[1].Name()))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(target).To(Equal("testdata/SecureTrust_CA.pem"))
 			Expect(fis[1].Name()).To(Equal("f39fc864.0"))
 
-			Expect(fis[2].Mode() & os.ModeType).To(Equal(os.ModeSymlink))
+			info, err = fis[2].Info()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.Mode() & os.ModeType).To(Equal(os.ModeSymlink))
 			target, err = os.Readlink(filepath.Join(dir, fis[2].Name()))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(target).To(Equal("testdata/SecureTrust_CA_Duplicate.pem"))
@@ -91,7 +94,7 @@ func testCerts(t *testing.T, context spec.G, it spec.S) {
 
 	context("SubjectNameHash", func() {
 		it("matches openssl", func() {
-			raw, err := ioutil.ReadFile(filepath.Join("testdata", "Go_Daddy_Class_2_CA.pem"))
+			raw, err := os.ReadFile(filepath.Join("testdata", "Go_Daddy_Class_2_CA.pem"))
 			Expect(err).NotTo(HaveOccurred())
 			block, rest := pem.Decode(raw)
 			Expect(rest).To(BeEmpty())
@@ -103,7 +106,7 @@ func testCerts(t *testing.T, context spec.G, it spec.S) {
 			// openssl x509 -hash -in ./cacerts/testdata/Go_Daddy_Class_2_CA.pem -> f081611a
 			Expect(hash).To(Equal(uint32(0xF081611A)))
 
-			raw, err = ioutil.ReadFile(filepath.Join("testdata", "SecureTrust_CA.pem"))
+			raw, err = os.ReadFile(filepath.Join("testdata", "SecureTrust_CA.pem"))
 			Expect(err).NotTo(HaveOccurred())
 			block, rest = pem.Decode(raw)
 			Expect(rest).To(BeEmpty())
@@ -121,7 +124,7 @@ func testCerts(t *testing.T, context spec.G, it spec.S) {
 		context("cert contains non-UTF8String values", func() {
 			var subject []byte
 			it.Before(func() {
-				raw, err := ioutil.ReadFile(filepath.Join("testdata", "Go_Daddy_Class_2_CA.pem"))
+				raw, err := os.ReadFile(filepath.Join("testdata", "Go_Daddy_Class_2_CA.pem"))
 				Expect(err).NotTo(HaveOccurred())
 				block, rest := pem.Decode(raw)
 				Expect(rest).To(BeEmpty())
@@ -191,7 +194,7 @@ func testCerts(t *testing.T, context spec.G, it spec.S) {
 		var dir string
 		it.Before(func() {
 			var err error
-			dir, err = ioutil.TempDir("", "multi-certs")
+			dir = t.TempDir()
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/cacerts/execd.go
+++ b/cacerts/execd.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package cacerts
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +57,7 @@ func (e *ExecD) Execute() (map[string]string, error) {
 	if len(paths) == 0 {
 		return env, nil
 	}
-	certDir, err := ioutil.TempDir("", "ca-certificates")
+	certDir, err := os.MkdirTemp("", "ca-certificates")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir\n%w", err)
 	}

--- a/cacerts/trusted_ca_certs_test.go
+++ b/cacerts/trusted_ca_certs_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package cacerts_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,10 +47,10 @@ func testTrustedCACerts(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		certsDir, err = ioutil.TempDir("", "ca-cert-files")
+		certsDir = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
-		layerDir, err = ioutil.TempDir("", "ca-certs-layer")
+		layerDir = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
 		layers := &libcnb.Layers{Path: layerDir}
@@ -73,7 +72,7 @@ func testTrustedCACerts(t *testing.T, context spec.G, it spec.S) {
 
 		for _, caCert := range caCertsList {
 			Expect(os.MkdirAll(filepath.Dir(caCert), 0755)).ToNot(HaveOccurred())
-			Expect(ioutil.WriteFile(caCert, []byte{}, 0644)).ToNot(HaveOccurred())
+			Expect(os.WriteFile(caCert, []byte{}, 0644)).ToNot(HaveOccurred())
 		}
 
 		trustedCAs = cacerts.NewTrustedCACerts(caCertsList, false)


### PR DESCRIPTION
## Summary

- Fixes buildpack.toml typo in metadata
- Removes ioutil and other deprecations
- Fixes missing error handling in a couple places
- Sets default values as strings so they show up in config output

## Use Cases

Bugs == bad
