### PR TITLE
Buildpack fails when an empty certificate file is passed.

### DIFF
--- a/cacerts/certs.go
+++ b/cacerts/certs.go
@@ -179,6 +179,10 @@ func SplitCerts(path string, certDir string) ([]string, error) {
 		return nil, fmt.Errorf("failed to read file at path %q\n%w", path, err)
 	}
 
+	if len(raw) == 0 {
+		return paths, nil // exit silently if raw is blank
+	}
+
 	block, rest = pem.Decode(raw)
 	if block == nil {
 		return nil, fmt.Errorf("failed to decode PEM data")

--- a/cacerts/certs_test.go
+++ b/cacerts/certs_test.go
@@ -219,6 +219,11 @@ func testCerts(t *testing.T, context spec.G, it spec.S) {
 			Expect(paths).To(HaveLen(1))
 			Expect(paths[0]).To(Equal(filepath.Join("testdata", "SecureTrust_CA.pem")))
 		})
+		it("exits silently if file is blank", func() {
+			paths, err := cacerts.SplitCerts(filepath.Join("testdata", "empty.pem"), dir)
+			Expect(err).To(BeNil())
+			Expect(paths).To(BeEmpty())
+		})
 		it("returns an error when PEM data cannot be read", func() {
 			_, err := cacerts.SplitCerts(filepath.Join("testdata", "SecureTrust_CA-corrupt.pem"), dir)
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Fails with following error:

failed to split certificates at path /cnb/bindings/cacerts/my-empty.pem failed to decode PEM data

Ignore empty files silently.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
