### PR TITLE
Remove Spurious Whitespace on remainder

### DIFF
--- a/cacerts/certs.go
+++ b/cacerts/certs.go
@@ -17,6 +17,7 @@
 package cacerts
 
 import (
+	"bytes"
 	"crypto/sha1"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -194,6 +195,7 @@ func SplitCerts(path string, certDir string) ([]string, error) {
 		}
 		paths = append(paths, newCertPath)
 		block, rest = pem.Decode(rest)
+		rest = bytes.TrimSpace(rest) // ignore any lines containing all spaces
 		if block == nil && len(rest) > 0 {
 			return nil, fmt.Errorf("failed to decode PEM data")
 		}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change allows PEM files with trailing newlines to get included in a build pack without failing. 
Fixes #269 

## Use Cases
<!-- An explanation of the use cases your change enables -->
If a PEM file has extra whitespace, the Decoder returns it as possibly un-de-coded data. This pull allows that data to be ignored, eliminating an unexpected error. 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
